### PR TITLE
added improved error handling in case of feed parsing errors

### DIFF
--- a/tonie_podcast_sync/podcast.py
+++ b/tonie_podcast_sync/podcast.py
@@ -48,6 +48,8 @@ class Podcast:
         self.epSorting = episode_sorting  # the sorting of the episode list
 
         self.feed = feedparser.parse(url)
+        if(self.feed.bozo):
+            raise self.feed.bozo_exception
         self.title = self.feed.feed.title  # title of podcast
         self.refresh_feed()  # reads feed and populates the episode list
 


### PR DESCRIPTION
Improves #28 

Error message now:
URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate
(_ssl.c:1000)>

Which leads to the right resolution via Google.

Thank you for doing this. I woke up yesterday and planned to develop the exact same thing :) I love the power of open source!