### PR TITLE
Surface wipe setting in settings.toml and default to no softwrapped logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ episode_max_duration_sec = 5400  # Maximum total duration of epsiodes on this to
 volume_adjustment = 0  # volume adjustment in dB (+/-)
 excluded_title_strings = ["vampir", "brokkoli"]  # filter out scary episodes
 pinned_episode_names = ["the golden goose", "hans in luck"] # pin certain episodes to be always uploaded
+wipe = true  # Whether to clear existing content before syncing (optional, defaults to true)
 ```
 
 The `excluded_title_strings` field is optional and allows you to filter out episodes whose titles contain any of the specified strings (case-insensitive matching).
@@ -73,6 +74,8 @@ The `excluded_title_strings` field is optional and allows you to filter out epis
 The `pinned_episode_names` field is optional and allows you to pin (i.e. always upload) episodes whose titles contain any of the specified episode names (case-insensitive matching).
 
 The `episode_max_duration_sec` field is optional. It filters out individual episodes that exceed this duration. Note that this is different from `maximum_length`, which controls the total duration of episodes placed on the tonie.
+
+The `wipe` field is optional and controls whether existing content on the tonie should be cleared before syncing new episodes. If set to `true` (the default), all existing content will be removed before adding new episodes. If set to `false`, new episodes will be appended to existing content.
 
 To periodically fetch for new episodes, you can schedule `tonie-podcast-sync` e.g. via systemd (on a Linux OS).
 

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -1,0 +1,27 @@
+# Example settings.toml configuration
+# This file demonstrates how to configure settings with the new wipe parameter
+
+[creative_tonies."tonie-id-12345"]
+podcast = "https://example.com/podcast-feed.xml"
+name = "My First Tonie"
+episode_sorting = "by_date_newest_first"
+maximum_length = 90
+episode_min_duration_sec = 0
+volume_adjustment = 0
+wipe = true  # This tonie will be wiped before each sync (default behavior)
+
+[creative_tonies."tonie-id-67890"]
+podcast = "https://example.com/another-feed.xml"
+name = "My Second Tonie"
+episode_sorting = "by_date_oldest_first"
+maximum_length = 60
+episode_min_duration_sec = 0
+volume_adjustment = 5
+wipe = false  # This tonie will have new episodes appended without wiping
+
+[creative_tonies."tonie-id-abcde"]
+podcast = "https://example.com/third-feed.xml"
+name = "My Third Tonie"
+episode_sorting = "random"
+maximum_length = 45
+# Note: wipe parameter omitted - will default to true

--- a/tests/test_wipe_setting.py
+++ b/tests/test_wipe_setting.py
@@ -1,0 +1,183 @@
+"""Tests for the wipe setting in settings.toml."""
+
+from unittest import mock
+
+
+def test_wipe_parameter_defaults_to_true_when_omitted():
+    """Test that wipe defaults to True when not specified in config.
+
+    This verifies that:
+    1. The code calls tonie_config.get("wipe", True)
+    2. When "wipe" is not in the config, the default True is used
+    3. The value is passed to sync_podcast_to_tonie
+    """
+    # Create mock settings
+    mock_settings = mock.MagicMock()
+    mock_settings.TONIE_CLOUD_ACCESS.USERNAME = "test_user"
+    mock_settings.TONIE_CLOUD_ACCESS.PASSWORD = "test_pass"
+
+    # Configure a tonie config - use a real dict to simulate dynaconf Box behavior
+    # The config does NOT have a "wipe" key
+    mock_tonie_config = mock.MagicMock()
+    mock_tonie_config.podcast = "https://example.com/feed.xml"
+    mock_tonie_config.episode_sorting = "by_date_newest_first"
+    mock_tonie_config.volume_adjustment = 0
+    mock_tonie_config.episode_min_duration_sec = 0
+    mock_tonie_config.maximum_length = 90
+
+    # Create a mock for .get() that tracks calls
+    mock_get = mock.MagicMock(side_effect=lambda key, default=None: {
+        "excluded_title_strings": [],
+        "pinned_episode_names": [],
+        "episode_max_duration_sec": 5400,
+    }.get(key, default))
+    mock_tonie_config.get = mock_get
+
+    mock_settings.CREATIVE_TONIES = {"test-tonie-id": mock_tonie_config}
+
+    # Mock the dependencies
+    with (
+        mock.patch("tonie_podcast_sync.cli.settings", mock_settings),
+        mock.patch("tonie_podcast_sync.cli.ToniePodcastSync") as mock_tps_class,
+        mock.patch("tonie_podcast_sync.cli.Podcast") as mock_podcast_class,
+    ):
+        # Mock ToniePodcastSync instance
+        mock_tps_instance = mock.MagicMock()
+        mock_tps_class.return_value = mock_tps_instance
+
+        # Mock Podcast class
+        mock_podcast_instance = mock.MagicMock()
+        mock_podcast_class.return_value = mock_podcast_instance
+
+        # Import and run the update_tonies function
+        from tonie_podcast_sync.cli import update_tonies  # noqa: PLC0415
+
+        update_tonies()
+
+        # VERIFY: The code called .get("wipe", True) on the config
+        mock_get.assert_any_call("wipe", True)
+
+        # VERIFY: sync_podcast_to_tonie was called with wipe=True (the default)
+        mock_tps_instance.sync_podcast_to_tonie.assert_called_once()
+        call_kwargs = mock_tps_instance.sync_podcast_to_tonie.call_args.kwargs
+        assert call_kwargs["wipe"] is True, "wipe should default to True when not specified in config"
+
+
+def test_wipe_parameter_respects_false_value():
+    """Test that wipe=False is passed through correctly.
+
+    This verifies that:
+    1. The code calls tonie_config.get("wipe", True)
+    2. When "wipe" is False in the config, that value is retrieved
+    3. The False value is passed to sync_podcast_to_tonie
+    """
+    # Create mock settings
+    mock_settings = mock.MagicMock()
+    mock_settings.TONIE_CLOUD_ACCESS.USERNAME = "test_user"
+    mock_settings.TONIE_CLOUD_ACCESS.PASSWORD = "test_pass"
+
+    # Configure a tonie config with wipe=False
+    mock_tonie_config = mock.MagicMock()
+    mock_tonie_config.podcast = "https://example.com/feed.xml"
+    mock_tonie_config.episode_sorting = "by_date_newest_first"
+    mock_tonie_config.volume_adjustment = 0
+    mock_tonie_config.episode_min_duration_sec = 0
+    mock_tonie_config.maximum_length = 90
+
+    # Set wipe=False explicitly in the config
+    mock_get = mock.MagicMock(side_effect=lambda key, default=None: {
+        "excluded_title_strings": [],
+        "pinned_episode_names": [],
+        "episode_max_duration_sec": 5400,
+        "wipe": False,  # Explicit False value in config
+    }.get(key, default))
+    mock_tonie_config.get = mock_get
+
+    mock_settings.CREATIVE_TONIES = {"test-tonie-id": mock_tonie_config}
+
+    # Mock the dependencies
+    with (
+        mock.patch("tonie_podcast_sync.cli.settings", mock_settings),
+        mock.patch("tonie_podcast_sync.cli.ToniePodcastSync") as mock_tps_class,
+        mock.patch("tonie_podcast_sync.cli.Podcast") as mock_podcast_class,
+    ):
+        # Mock ToniePodcastSync instance
+        mock_tps_instance = mock.MagicMock()
+        mock_tps_class.return_value = mock_tps_instance
+
+        # Mock Podcast class
+        mock_podcast_instance = mock.MagicMock()
+        mock_podcast_class.return_value = mock_podcast_instance
+
+        # Import and run the update_tonies function
+        from tonie_podcast_sync.cli import update_tonies  # noqa: PLC0415
+
+        update_tonies()
+
+        # VERIFY: The code called .get("wipe", True) on the config
+        mock_get.assert_any_call("wipe", True)
+
+        # VERIFY: sync_podcast_to_tonie was called with wipe=False (from config)
+        mock_tps_instance.sync_podcast_to_tonie.assert_called_once()
+        call_kwargs = mock_tps_instance.sync_podcast_to_tonie.call_args.kwargs
+        assert call_kwargs["wipe"] is False, "wipe should be False when explicitly set to False in config"
+
+
+def test_wipe_parameter_respects_true_value():
+    """Test that wipe=True is passed through correctly when explicitly set.
+
+    This verifies that:
+    1. The code calls tonie_config.get("wipe", True)
+    2. When "wipe" is True in the config, that value is retrieved
+    3. The True value is passed to sync_podcast_to_tonie
+    """
+    # Create mock settings
+    mock_settings = mock.MagicMock()
+    mock_settings.TONIE_CLOUD_ACCESS.USERNAME = "test_user"
+    mock_settings.TONIE_CLOUD_ACCESS.PASSWORD = "test_pass"
+
+    # Configure a tonie config with wipe=True explicitly
+    mock_tonie_config = mock.MagicMock()
+    mock_tonie_config.podcast = "https://example.com/feed.xml"
+    mock_tonie_config.episode_sorting = "by_date_newest_first"
+    mock_tonie_config.volume_adjustment = 0
+    mock_tonie_config.episode_min_duration_sec = 0
+    mock_tonie_config.maximum_length = 90
+
+    # Set wipe=True explicitly in the config
+    mock_get = mock.MagicMock(side_effect=lambda key, default=None: {
+        "excluded_title_strings": [],
+        "pinned_episode_names": [],
+        "episode_max_duration_sec": 5400,
+        "wipe": True,  # Explicit True value in config
+    }.get(key, default))
+    mock_tonie_config.get = mock_get
+
+    mock_settings.CREATIVE_TONIES = {"test-tonie-id": mock_tonie_config}
+
+    # Mock the dependencies
+    with (
+        mock.patch("tonie_podcast_sync.cli.settings", mock_settings),
+        mock.patch("tonie_podcast_sync.cli.ToniePodcastSync") as mock_tps_class,
+        mock.patch("tonie_podcast_sync.cli.Podcast") as mock_podcast_class,
+    ):
+        # Mock ToniePodcastSync instance
+        mock_tps_instance = mock.MagicMock()
+        mock_tps_class.return_value = mock_tps_instance
+
+        # Mock Podcast class
+        mock_podcast_instance = mock.MagicMock()
+        mock_podcast_class.return_value = mock_podcast_instance
+
+        # Import and run the update_tonies function
+        from tonie_podcast_sync.cli import update_tonies  # noqa: PLC0415
+
+        update_tonies()
+
+        # VERIFY: The code called .get("wipe", True) on the config
+        mock_get.assert_any_call("wipe", True)
+
+        # VERIFY: sync_podcast_to_tonie was called with wipe=True (from config)
+        mock_tps_instance.sync_podcast_to_tonie.assert_called_once()
+        call_kwargs = mock_tps_instance.sync_podcast_to_tonie.call_args.kwargs
+        assert call_kwargs["wipe"] is True, "wipe should be True when explicitly set to True in config"

--- a/tonie_podcast_sync/cli.py
+++ b/tonie_podcast_sync/cli.py
@@ -29,7 +29,8 @@ def update_tonies() -> None:
 
     for tonie_id, tonie_config in settings.CREATIVE_TONIES.items():
         podcast = _create_podcast_from_config(tonie_config)
-        tps.sync_podcast_to_tonie(podcast, tonie_id, tonie_config.maximum_length)
+        wipe = tonie_config.get("wipe", True)
+        tps.sync_podcast_to_tonie(podcast, tonie_id, tonie_config.maximum_length, wipe=wipe)
 
 
 def _create_tonie_podcast_sync() -> ToniePodcastSync | None:
@@ -185,6 +186,7 @@ def _configure_tonie_settings(configs: dict, tonie: CreativeTonie) -> None:
     _ask_maximum_tonie_length(configs, tonie)
     _ask_minimum_episode_length(configs, tonie)
     _ask_volume_adjustment(configs, tonie)
+    _ask_wipe_setting(configs, tonie)
 
 
 def _save_settings_file(configs: dict) -> None:
@@ -286,6 +288,23 @@ def _ask_volume_adjustment(configs: dict, tonie: CreativeTonie) -> None:
         configs[tonie.id]["volume_adjustment"] = 0
     else:
         configs[tonie.id]["volume_adjustment"] = volume_adjustment
+
+
+def _ask_wipe_setting(configs: dict, tonie: CreativeTonie) -> None:
+    """Ask user for wipe setting.
+
+    Args:
+        configs: The configuration dictionary to update
+        tonie: The tonie being configured
+    """
+    wipe = Confirm.ask(
+        "Should existing content be wiped before syncing new episodes?\n"
+        "If set to 'yes', the tonie will be cleared before adding new content.\n"
+        "If set to 'no', new episodes will be appended to existing content.\n"
+        "Defaults to 'yes' (wipe existing content)",
+        default=True,
+    )
+    configs[tonie.id]["wipe"] = wipe
 
 
 if __name__ == "__main__":

--- a/tonie_podcast_sync/toniepodcastsync.py
+++ b/tonie_podcast_sync/toniepodcastsync.py
@@ -28,7 +28,7 @@ from tonie_podcast_sync.constants import (
 )
 from tonie_podcast_sync.podcast import Episode, EpisodeSorting, Podcast, compare_unicode_caseless
 
-console = Console()
+console = Console(soft_wrap=False)
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 


### PR DESCRIPTION
I saw you had the wipe setting already in the code but it's not surfaced in the settings.toml. This PR does the following:

- Surfaces the wipe setting to the settings.toml per tonie
- Adds tests (with the help of Claude Sonnet)
- Turns softwrap console logging off.
  - This is done primarily in support of the docker container. With softwraps on, docker shows these logs occurring on multiple lines which makes actioning on them more difficult. With them in a single line, a user could grep for a `Successfully` log line and action upon it, or the inverse for errors.
  - With softwraps on, actioning on these log lines requires much more logic in reading lines, waiting, etc.